### PR TITLE
Improve upload error handling

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -438,7 +438,15 @@ class FileUpload {
             
         } catch (error) {
             console.error('File processing error:', error);
-            window.TeamAnalyzer.handleError(error, 'File Upload');
+            window.TeamAnalyzer.showNotification(
+                `Error processing ${file.name}: ${error.message}`,
+                'error',
+                8000
+            );
+            window.TeamAnalyzer.handleError(error, 'File Upload', {
+                category: 'file_processing',
+                severity: 'high'
+            });
             this.resetUpload();
         }
     }


### PR DESCRIPTION
## Summary
- add verbose notifications when file processing fails
- show detailed CSV parsing errors in the main workflow
- pass category and severity when handling CSV errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68497f98ce28832f9908113113267bea