### PR TITLE
Improve parse error handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -581,7 +581,12 @@ async function handleFileProcessed(file, content) {
                 ` Errors: ${parser.parseErrors.slice(0, 3).join('; ')}${parser.parseErrors.length > 3 ? '...' : ''}` : '';
             const message = `Failed to parse ${file.name}. ${parseError.message}.${firstErrors}`;
             showNotification(message, 'error', 10000);
-            handleError(parseError, 'CSV Parsing', { category: 'file_processing', severity: 'high' });
+            handleError(parseError, 'CSV Parsing', {
+                category: 'file_processing',
+                severity: 'high',
+                showNotification: false,
+                details: parser.parseErrors
+            });
             return;
         }
         


### PR DESCRIPTION
## Summary
- return parse errors to user notification
- suppress duplicate error notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684980cb8b98832f8d6ba7a7c9793ee6